### PR TITLE
Fix build when site_url is not set

### DIFF
--- a/mkdocs_document_dates/plugin.py
+++ b/mkdocs_document_dates/plugin.py
@@ -200,6 +200,8 @@ class DocumentDatesPlugin(BasePlugin):
 
         # 获取站点 URL 路径前缀
         site_url = config.get("site_url", "")
+        if site_url is None:
+            site_url = ""
         base_path = urlparse(site_url).path.rstrip("/")
         prefix = f"{base_path}/" if base_path else "/"
 


### PR DESCRIPTION
Currently, when `site_url` is not set, `properdocs build` fails with the following error:

```
Traceback (most recent call last):
  File "/usr/local/src/.venv/bin/properdocs", line 10, in <module>
    sys.exit(cli())
             ~~~^^
  File "/usr/local/src/.venv/lib/python3.14/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/local/src/.venv/lib/python3.14/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/usr/local/src/.venv/lib/python3.14/site-packages/click/core.py", line 1902, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/local/src/.venv/lib/python3.14/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/.venv/lib/python3.14/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/src/.venv/lib/python3.14/site-packages/properdocs/__main__.py", line 301, in build_command
    build.build(cfg, dirty=not clean)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/.venv/lib/python3.14/site-packages/properdocs/commands/build.py", line 329, in build
    env = config.plugins.on_env(env, config=config, files=files)
  File "/usr/local/src/.venv/lib/python3.14/site-packages/properdocs/plugins.py", line 605, in on_env
    return self.run_event('env', env, config=config, files=files)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/.venv/lib/python3.14/site-packages/properdocs/plugins.py", line 572, in run_event
    result = method(item, **kwargs)
  File "/usr/local/src/.venv/lib/python3.14/site-packages/mkdocs_document_dates/plugin.py", line 203, in on_env
    base_path = urlparse(site_url).path.rstrip("/")
TypeError: a bytes-like object is required, not 'str'
```

This is because when `site_url` is not explicitly set, it is `None`, which bypasses the default value specified in `config.get("site_url", "")`. When `urlparse` is called with `None`, it returns a result of type `bytes` instead `str`, which causes `.rstrip("/")` to fail (as its argument `"/"` is of type `str`).

## How to reproduce

1. create an empty ProperDocs site: `properdocs new .`
2. add the following to `properdocs.yaml`:
   ```
   theme: materialx

   plugins:
     - document-dates
   ```
3. run `properdocs build`
4. observe the error listed above